### PR TITLE
All-in-one publishForSale() function

### DIFF
--- a/contracts/Interfaces/TradableEntityDBInterface.sol
+++ b/contracts/Interfaces/TradableEntityDBInterface.sol
@@ -19,13 +19,10 @@ pragma experimental ABIEncoderV2;
 
 interface TradableEntityDBInterface {
 
-    /// @notice makes the tradable entity available for sale
+    /// @notice sets the forSale flag
     /// @param _entityId the id of the tradableEntity
-    function publishForSale(uint _entityId) external;
-
-    /// @notice makes the tradable entity unavailable to sell
-    /// @param _entityId the id of the tradableEntity
-    function unpublishForSale(uint _entityId) external;
+    /// @param _isForSale true/false
+    function setForSale(uint _entityId, bool _isForSale) external;
 
     /// @notice adds an approved address to an entity
     /// @param _entityId the id of the entity

--- a/contracts/Origin/CertificateLogic.sol
+++ b/contracts/Origin/CertificateLogic.sol
@@ -133,7 +133,7 @@ contract CertificateLogic is CertificateInterface, RoleManagement, TradableEntit
         simpleTransferInternal(cert.tradableEntity.owner, msg.sender, _certificateId);
         checktransferOwnerInternally(_certificateId, cert);
 
-        TradableEntityDBInterface(address(db)).unpublishForSale(_certificateId);
+        TradableEntityDBInterface(address(db)).setForSale(_certificateId, false);
     }
 
     /// @notice creates a new Entity / certificate

--- a/contracts/Origin/TradableEntityDB.sol
+++ b/contracts/Origin/TradableEntityDB.sol
@@ -46,20 +46,12 @@ contract TradableEntityDB is Owned,TradableEntityDBInterface {
 
     /// @notice makes the tradable entity available for sale
     /// @param _entityId the id of the tradableEntity
-    function publishForSale(uint _entityId) external onlyOwner {
+    /// @param _isForSale true/false
+    function setForSale(uint _entityId, bool _isForSale) external onlyOwner {
         TradableEntityContract.TradableEntity storage te = getTradableEntityInternally(_entityId);
-        require(te.forSale == false, "The tradable entity is already published for sale.");
+        require(te.forSale != _isForSale, "forSale flag is already set to the required value.");
 
-        te.forSale = true;
-    }
-
-    /// @notice makes the tradable entity unavailable to sell
-    /// @param _entityId the id of the tradableEntity
-    function unpublishForSale(uint _entityId) external onlyOwner {
-        TradableEntityContract.TradableEntity storage te = getTradableEntityInternally(_entityId);
-        require(te.forSale == true, "Unable to revoke the tradable entity from sale because the entity has not been posted for sale.");
-
-        te.forSale = false;
+        te.forSale = _isForSale;
     }
 
     /// @notice adds an escrow to an entity

--- a/contracts/Origin/TradableEntityLogic.sol
+++ b/contracts/Origin/TradableEntityLogic.sol
@@ -50,7 +50,7 @@ contract TradableEntityLogic is Updatable, RoleManagement, ERC721, ERC165, Trada
     event LogEscrowAdded(uint indexed _certificateId, address _escrow);
 
     /// @notice Logs when an entity is published for sale
-    event LogPublishForSale(uint indexed _entityId);
+    event LogPublishForSale(uint indexed _entityId, uint _price, address _token);
     /// @notice Logs when an entity is published for sale
     event LogUnpublishForSale(uint indexed _entityId);
 
@@ -159,15 +159,20 @@ contract TradableEntityLogic is Updatable, RoleManagement, ERC721, ERC165, Trada
 
     /// @notice makes the tradable entity available for sale
     /// @param _entityId The id of the certificate
-    function publishForSale(uint _entityId) external onlyEntityOwner(_entityId) {
-        db.publishForSale(_entityId);
-        emit LogPublishForSale(_entityId);
+    /// @param _price the purchase price
+    /// @param _tokenAddress the address of the ERC20 token address
+    function publishForSale(uint _entityId, uint _price, address _tokenAddress) external onlyEntityOwner(_entityId) {
+        db.setOnChainDirectPurchasePrice(_entityId, _price);
+        db.setTradableToken(_entityId, _tokenAddress);
+        db.setForSale(_entityId, true);
+
+        emit LogPublishForSale(_entityId, _price, _tokenAddress);
     }
 
     /// @notice makes the tradable entity available for sale
     /// @param _entityId The id of the certificate
     function unpublishForSale(uint _entityId) external onlyEntityOwner(_entityId) {
-        db.unpublishForSale(_entityId);
+        db.setForSale(_entityId, false);
         emit LogUnpublishForSale(_entityId);
     }
 

--- a/src/blockchain-facade/TradableEntity.ts
+++ b/src/blockchain-facade/TradableEntity.ts
@@ -257,15 +257,19 @@ export abstract class Entity extends BlockchainDataModelEntity.Entity
         }
     }
 
-    async publishForSale(): Promise<TransactionReceipt> {
+    async publishForSale(price: number, tokenAddress: string): Promise<TransactionReceipt> {
         if (this.configuration.blockchainProperties.activeUser.privateKey) {
             return this.configuration.blockchainProperties.certificateLogicInstance.publishForSale(
                 this.id,
+                price,
+                tokenAddress,
                 { privateKey: this.configuration.blockchainProperties.activeUser.privateKey }
             );
         } else {
             return this.configuration.blockchainProperties.certificateLogicInstance.publishForSale(
                 this.id,
+                price,
+                tokenAddress,
                 { from: this.configuration.blockchainProperties.activeUser.address }
             );
         }

--- a/src/test/CertificateLogicContracts.ts
+++ b/src/test/CertificateLogicContracts.ts
@@ -3100,7 +3100,7 @@ describe('CertificateLogic', () => {
             });
 
             it('should set certificate for sale', async () => {
-                await certificateLogic.publishForSale(15, { privateKey: assetOwnerPK });
+                await certificateLogic.publishForSale(15, 0, erc20Test.web3Contract._address, { privateKey: assetOwnerPK });
                 const cert = await certificateLogic.getCertificate(15);
 
                 assert.isTrue(cert.tradableEntity.forSale);

--- a/src/wrappedContracts/CertificateDB.ts
+++ b/src/wrappedContracts/CertificateDB.ts
@@ -1851,10 +1851,10 @@ export class CertificateDB extends GeneralFunctions {
         }
     }
 
-    async publishForSale(_entityId: number, txParams?: SpecialTx) {
+    async publishForSale(_entityId: number, _price: number, _tokenAddress: string, txParams?: SpecialTx) {
         let transactionParams;
 
-        const txData = await this.web3Contract.methods.publishForSale(_entityId).encodeABI();
+        const txData = await this.web3Contract.methods.publishForSale(_entityId, _price, _tokenAddress).encodeABI();
 
         let gas;
 
@@ -1872,7 +1872,7 @@ export class CertificateDB extends GeneralFunctions {
             if (!txParams.gas) {
                 try {
                     gas = await this.web3Contract.methods
-                        .publishForSale(_entityId)
+                        .publishForSale(_entityId, _price, _tokenAddress)
                         .estimateGas({
                             from: txParams ? txParams.from : (await this.web3.eth.getAccounts())[0]
                         });
@@ -1925,7 +1925,7 @@ export class CertificateDB extends GeneralFunctions {
             return await this.sendRaw(this.web3, transactionParams.privateKey, transactionParams);
         } else {
             return await this.web3Contract.methods
-                .publishForSale(_entityId)
+                .publishForSale(_entityId, _price, _tokenAddress)
                 .send({ from: transactionParams.from, gas: transactionParams.gas });
         }
     }

--- a/src/wrappedContracts/CertificateLogic.ts
+++ b/src/wrappedContracts/CertificateLogic.ts
@@ -1341,11 +1341,11 @@ export class CertificateLogic extends GeneralFunctions {
         }
     }
 
-    async publishForSale(_certificateId: number, txParams?: SpecialTx) {
+    async publishForSale(_certificateId: number, _price: number, _tokenAddress: string, txParams?: SpecialTx) {
         let transactionParams;
 
         const txData = await this.web3Contract.methods
-            .publishForSale(_certificateId)
+            .publishForSale(_certificateId, _price, _tokenAddress)
             .encodeABI();
 
         let gas;
@@ -1364,7 +1364,7 @@ export class CertificateLogic extends GeneralFunctions {
             if (!txParams.gas) {
                 try {
                     gas = await this.web3Contract.methods
-                        .publishForSale(_certificateId)
+                        .publishForSale(_certificateId, _price, _tokenAddress)
                         .estimateGas({
                             from: txParams ? txParams.from : (await this.web3.eth.getAccounts())[0]
                         });
@@ -1417,7 +1417,7 @@ export class CertificateLogic extends GeneralFunctions {
             return await this.sendRaw(this.web3, transactionParams.privateKey, transactionParams);
         } else {
             return await this.web3Contract.methods
-                .publishForSale(_certificateId)
+                .publishForSale(_certificateId, _price, _tokenAddress)
                 .send({ from: transactionParams.from, gas: transactionParams.gas });
         }
     }

--- a/src/wrappedContracts/EnergyCertificateBundleDB.ts
+++ b/src/wrappedContracts/EnergyCertificateBundleDB.ts
@@ -1748,10 +1748,10 @@ export class EnergyCertificateBundleDB extends GeneralFunctions {
 
 
 
-    async publishForSale(_entityId: number, txParams?: SpecialTx) {
+    async publishForSale(_entityId: number, _price: number, _tokenAddress: string, txParams?: SpecialTx) {
         let transactionParams;
 
-        const txData = await this.web3Contract.methods.publishForSale(_entityId).encodeABI();
+        const txData = await this.web3Contract.methods.publishForSale(_entityId, _price, _tokenAddress).encodeABI();
 
         let gas;
 
@@ -1769,7 +1769,7 @@ export class EnergyCertificateBundleDB extends GeneralFunctions {
             if (!txParams.gas) {
                 try {
                     gas = await this.web3Contract.methods
-                        .publishForSale(_entityId)
+                        .publishForSale(_entityId, _price, _tokenAddress)
                         .estimateGas({
                             from: txParams ? txParams.from : (await this.web3.eth.getAccounts())[0]
                         });
@@ -1822,7 +1822,7 @@ export class EnergyCertificateBundleDB extends GeneralFunctions {
             return await this.sendRaw(this.web3, transactionParams.privateKey, transactionParams);
         } else {
             return await this.web3Contract.methods
-                .publishForSale(_entityId)
+                .publishForSale(_entityId, _price, _tokenAddress)
                 .send({ from: transactionParams.from, gas: transactionParams.gas });
         }
     }


### PR DESCRIPTION
Fixes the issue where the user would need to do 3 transactions in order to publish a tradable entity for sale.